### PR TITLE
Improved use of memory in ScreenPlotter, some bug fixes and an enhancement

### DIFF
--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -109,6 +109,33 @@ def test_twolinesfewdraws(name, full_refresh=False):
             test_splotter.draw(full_refresh=full_refresh)
 
 
+def test_altandmiss(name, full_refresh=False):
+    """Draw three lines which alternate values to allow visual check on scrolling.
+       Also misses values on third line.
+    """
+    test_splotter = plotter.ScreenPlotter([red+green, green+blue, red+(blue>>1)],
+                                          top_space=10+10,
+                                          display=screen)
+
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text=name + (" CLS" if full_refresh else ""),
+                                           color=0xffffff, x=0, y=5))
+
+
+    for idx in range(180):
+        if idx >= 140:
+            time.sleep(0.25)
+
+        values = [40960 - idx % 2 * 2048,
+                  24576 + idx % 4 * 1024]
+        if idx % 4 >= 2:
+            values.append(32768)
+        test_splotter.update(*values,
+                             draw=not full_refresh)
+        if full_refresh:
+            test_splotter.draw(full_refresh=full_refresh)
+
+
 # full_refresh is currently (Dec-2020) very slow and very flickery unless
 # data update rate is very low
 screen_name = "Four lines, 3 ramping"
@@ -131,7 +158,6 @@ print(screen_name, "took",
       "seconds")
 time.sleep(15)
 
-
 screen_name = "Two lines, few draws"
 print(screen_name, "took",
       timeit(lambda: test_twolinesfewdraws(screen_name)),
@@ -139,5 +165,15 @@ print(screen_name, "took",
 time.sleep(10)
 print(screen_name, "took",
       timeit(lambda: test_twolinesfewdraws(screen_name, full_refresh=True)),
+      "seconds")
+time.sleep(15)
+
+screen_name = "Alternating, missing"
+print(screen_name, "took",
+      timeit(lambda: test_altandmiss(screen_name)),
+      "seconds")
+time.sleep(10)
+print(screen_name, "took",
+      timeit(lambda: test_altandmiss(screen_name, full_refresh=True)),
       "seconds")
 time.sleep(15)

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -1,0 +1,92 @@
+"""
+plotter_test.py
+
+This only tests some aspects of the plotter object.
+It does not display any data from the Enviro+ FeatherWing.
+"""
+
+
+import time
+import gc
+
+import pulseio
+import terminalio
+from adafruit_display_text import label
+
+import pimoroni_physical_feather_pins
+from pimoroni_envirowing import screen
+from pimoroni_envirowing.screen import plotter
+
+
+# Setup screen - this returns an ST7735R object
+screen = screen.Screen(backlight_control=False)
+
+# PWM for screen brightness
+backlight_pwm = pulseio.PWMOut(pimoroni_physical_feather_pins.pin21())
+backlight_pwm.duty_cycle = 65535  # full brightness
+
+red = 0xFF0000
+green = 0x00FF00
+blue = 0x0000FF
+
+
+def test_fourlines(name, full_refresh=False):
+    test_splotter = plotter.ScreenPlotter([red, green, blue, red+green+blue],
+                                          min_value=0, max_value=100, top_space=10+10,
+                                          display=screen)
+
+    # add a colour coded text label for each reading
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text="A: {:.0f}",
+                                           color=red, x=0, y=5, max_glyphs=15))
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text="B: {:.0f}",
+                                           color=green, x=50, y=5, max_glyphs=15))
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text="C: {:.0f}",
+                                           color=blue, x=110, y=5, max_glyphs=15))
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text=name + (" CLS" if full_refresh else ""),
+                                           color=0xffffff, x=0, y=5))
+
+    for idx in range(200):
+        time.sleep(0.050)
+        test_splotter.update((idx * 2 + 50) % 121,
+                             (idx * 2 + 20) % 101,
+                             idx * 4 % 101,
+                             50,
+                             draw=not full_refresh)
+        if full_refresh:
+            test_splotter.draw(full_refresh)
+
+
+def test_threeflatlines(name, full_refresh=False):
+    test_splotter = plotter.ScreenPlotter([red, green, blue],
+                                          min_value=0, max_value=100, top_space=10,
+                                          display=screen)
+
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text=name + (" CLS" if full_refresh else ""),
+                                           color=0xffffff, x=0, y=5))
+
+    for _ in range(200):
+        time.sleep(0.050)
+        test_splotter.update(0,
+                             50,
+                             100,
+                             draw=not full_refresh)
+
+        if full_refresh:
+            test_splotter.draw(full_refresh)
+
+
+# full_refresh is currently (Dec-2020) very slow and very flickery unless
+# data update rate is very low
+test_fourlines("Four lines, 3 ramping")
+time.sleep(10)
+test_fourlines("Four lines, 3 ramping", full_refresh=True)
+time.sleep(15)
+test_threeflatlines("Three flat lines")
+time.sleep(10)
+test_threeflatlines("Three flat lines", full_refresh=True)
+time.sleep(15)

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -102,13 +102,17 @@ def test_twolinesfewdraws(name, full_refresh=False):
                                            color=0xffffff, x=0, y=5))
     screen.show(test_splotter.group)
 
-    for idx in range(200):
+    for idx in range(200 + 32):
         time.sleep(0.050)
         test_splotter.update((idx * 50 + 20) % 1001,
                              (idx * 2 + 300) % 1001,
                              draw=False)
-        if idx % 4 == 0:
+        # draw every 4 columns for first 200 columns but skip after that to
+        # test going beyond internal circular buffer size
+        if idx % 4 == 0 and idx < 200:
             test_splotter.draw(full_refresh=full_refresh)
+
+    test_splotter.draw(full_refresh=full_refresh)
 
 
 def test_altandmiss(name, full_refresh=False):

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -41,7 +41,7 @@ def timeit(func):
 def test_fourlines(name, full_refresh=False):
     test_splotter = plotter.ScreenPlotter([red, green, blue, red+green+blue],
                                           min_value=0, max_value=100, top_space=10+10,
-                                          display=screen)
+                                          display=screen, auto_show=False)
 
     # add a colour coded text label for each reading
     test_splotter.group.append(label.Label(terminalio.FONT,
@@ -56,6 +56,7 @@ def test_fourlines(name, full_refresh=False):
     test_splotter.group.append(label.Label(terminalio.FONT,
                                            text=name + (" CLS" if full_refresh else ""),
                                            color=0xffffff, x=0, y=5))
+    screen.show(test_splotter.group)
 
     for idx in range(200):
         time.sleep(0.050)
@@ -94,11 +95,12 @@ def test_twolinesfewdraws(name, full_refresh=False):
     """
     test_splotter = plotter.ScreenPlotter([red+green, green+blue],
                                           min_value=0, max_value=1000, top_space=10+10,
-                                          display=screen)
+                                          display=screen, auto_show=False)
 
     test_splotter.group.append(label.Label(terminalio.FONT,
                                            text=name + (" CLS" if full_refresh else ""),
                                            color=0xffffff, x=0, y=5))
+    screen.show(test_splotter.group)
 
     for idx in range(200):
         time.sleep(0.050)
@@ -115,12 +117,12 @@ def test_altandmiss(name, full_refresh=False):
     """
     test_splotter = plotter.ScreenPlotter([red+green, green+blue, red+(blue>>1)],
                                           top_space=10+10,
-                                          display=screen)
+                                          display=screen, auto_show=False)
 
     test_splotter.group.append(label.Label(terminalio.FONT,
                                            text=name + (" CLS" if full_refresh else ""),
                                            color=0xffffff, x=0, y=5))
-
+    screen.show(test_splotter.group)
 
     for idx in range(180):
         if idx >= 140:

--- a/examples/plotters_combined.py
+++ b/examples/plotters_combined.py
@@ -174,7 +174,7 @@ while True:
         # if proximity confidence above threshold, change page
         if prox > prox_threshold:
             current_page = next(page)
-            available_pages[current_page].draw(full_refresh=True)
+            available_pages[current_page].draw(full_refresh=True, show=True)
         else:
             # change screen brightness according to the amount of light detected
             pwm.duty_cycle = int(min(lightandsound_splotter.remap(lux, 0, 400, 0, (2**16 - 1)), (2**16 - 1)))

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -1,7 +1,7 @@
 class ScreenPlotter:
     def __init__(self, colours, bg_colour=None, max_value=None, min_value=None,
                  display=None, top_space=None, width=None, height=None,
-                 extra_data=16):
+                 extra_data=16, auto_show=True):
         """__init__
 
         :param list colours: a list of colours to use for data lines
@@ -21,6 +21,8 @@ class ScreenPlotter:
         :param int height: the height in pixels of the plot (uses display width if not supplied)
 
         :param int extra_data: the number of updates that can be applied before a draw (16 if not supplied)
+
+        :param bool auto_show: invoke show on the displayio object here and per execution of draw() (default True)
         """
         import displayio
 
@@ -55,12 +57,12 @@ class ScreenPlotter:
             self.palette[i + 1] = j
 
         self.tile_grid = displayio.TileGrid(self.bitmap, pixel_shader=self.palette, y=self.top_offset)
-
         self.group = displayio.Group(max_size=12)
-
         self.group.append(self.tile_grid)
 
-        self.display.show(self.group)
+        self.auto_show = auto_show
+        if self.auto_show:
+            self.display.show(self.group)
 
         if max_value:
             self.max_value = max_value
@@ -113,11 +115,13 @@ class ScreenPlotter:
         if draw:
             self.draw()
 
-    def draw(self, full_refresh=False):
+    def draw(self, full_refresh=False, show=False):
         """draw
 
         :param bool full_refresh: select clear bitmap algorithm when scrolling,
                                   default is to undraw individual prevously drawn pixels
+
+        :param bool show: force show on the displayio object (default False)
         """
         new_points = (self.data_tail - self.display_tail if self.data_tail >= self.display_tail
                       else self.data_len - self.display_tail + self.data_tail)
@@ -170,3 +174,7 @@ class ScreenPlotter:
 
         if restore_auto_refresh:
             self.display.auto_refresh = True
+
+        # Slightly inefficient and generally unnecessary to show() per draw
+        if show or self.auto_show:
+            self.display.show(self.group)

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -110,6 +110,11 @@ class ScreenPlotter:
             self.draw()
 
     def draw(self, full_refresh=False):
+        restore_auto_refresh = False
+        if self.display.auto_refresh:
+            self.display.auto_refresh = False
+            restore_auto_refresh = True
+
         if not full_refresh:
             if len(self.data_points) > self.bitmap.width:
                 difflen = len(self.data_points) - self.bitmap.width
@@ -152,4 +157,6 @@ class ScreenPlotter:
                         self.bitmap[index, round(self.remap(point, self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1
             except IndexError:
                 print("You shouldn't call draw() without calling update() first")
-        self.display.show(self.group)
+
+        if restore_auto_refresh:
+            self.display.auto_refresh = True

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -134,7 +134,7 @@ class ScreenPlotter:
         """
         new_points = (self.data_tail - self.display_tail if self.data_tail >= self.display_tail
                       else self.data_len - self.display_tail + self.data_tail)
-        if new_points == 0:
+        if new_points == 0 and not full_refresh and not show:
             return
 
         restore_auto_refresh = False

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -144,9 +144,7 @@ class ScreenPlotter:
                     self.data_points = self.data_points[difflen:]
 
                 # clear bitmap
-                for x in range(self.bitmap.width):
-                    for y in range(self.bitmap.height):
-                        self.bitmap[x, y] = 0
+                self.bitmap.fill(0)
 
                 for index, value in enumerate(self.data_points):
                     for subindex, point in enumerate(value):

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -31,7 +31,6 @@ class ScreenPlotter:
         else:
             self.display = display
 
-        self.num_lines = len(colours)
         self.num_colours = len(colours) + 1
 
         plot_width = display.width if width is None else width
@@ -99,8 +98,8 @@ class ScreenPlotter:
         if self.data_tail == (self.data_head - 1) % self.data_len:
             raise OverflowError("data_points full")
 
-        if len(values) != self.num_lines:
-            raise Exception("The list of values should match the number of colours")
+        if len(values) > self.num_colours - 1:
+            raise OverflowError("The list of values shouldn't have more entries than the list of colours")
 
         for i, j in enumerate(values):
             if j > self.max_value:
@@ -139,10 +138,10 @@ class ScreenPlotter:
                 for index, dpnew_index in zip(range(self.bitmap.width),
                                               range(self.data_tail - self.bitmap.width, self.data_tail)):
                     # undraw old pixels if they were in a different position
-                    for subindex, new_value in enumerate(self.data_points[dpnew_index]):
-                        old_values = self.data_points[self.display_tail - self.displayed_points + index] if index < self.displayed_points else None
-                        if old_values is not None and old_values[subindex] != new_value:
-                            self.bitmap[index, round(self.remap(old_values[subindex], self.min_value, self.max_value, heightm1, 0))] = 0
+                    old_values = self.data_points[self.display_tail - self.displayed_points + index] if index < self.displayed_points else []
+                    for old_value in old_values:
+                        self.bitmap[index, round(self.remap(old_value, self.min_value, self.max_value, heightm1, 0))] = 0
+
                     # draw new pixels - this must be performed unconditionally
                     # to cater for overlapping lines
                     for subindex, new_value in enumerate(self.data_points[dpnew_index]):

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -133,8 +133,9 @@ class ScreenPlotter:
                         if point != 0:
                             # self.bitmap[index,round(((old_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = 0
                             self.bitmap[index, round(self.remap(self.old_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = 0
-                            # self.bitmap[index,round(((self.data_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = subindex + 1
-                            self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1
+                    for subindex, point in enumerate(value):
+                        # self.bitmap[index,round(((self.data_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = subindex + 1
+                        self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1                 
             else:
                 try:
                     for subindex, point in enumerate(self.data_points[-1]):

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -37,8 +37,8 @@ class ScreenPlotter:
 
         self.num_colours = len(colours) + 1
 
-        plot_width = display.width if width is None else width
-        plot_height = display.height if height is None else height
+        plot_width = self.display.width if width is None else width
+        plot_height = self.display.height if height is None else height
         if top_space:
             self.bitmap = displayio.Bitmap(plot_width, plot_height - top_space,
                                            self.num_colours)

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -1,5 +1,6 @@
 class ScreenPlotter:
-    def __init__(self, colours, bg_colour=None, max_value=None, min_value=None, display=None, top_space=None):
+    def __init__(self, colours, bg_colour=None, max_value=None, min_value=None,
+                 display=None, top_space=None, width=None, height=None):
         """__init__
 
         :param list colours: a list of colours to use for data lines
@@ -25,11 +26,15 @@ class ScreenPlotter:
 
         self.num_colours = len(colours) + 1
 
+        plot_width = display.width if width is None else width
+        plot_height = display.height if height is None else height
         if top_space:
-            self.bitmap = displayio.Bitmap(160, 80 - top_space, self.num_colours)
+            self.bitmap = displayio.Bitmap(plot_width, plot_height - top_space,
+                                           self.num_colours)
             self.top_offset = top_space
         else:
-            self.bitmap = displayio.Bitmap(160, 80, self.num_colours)
+            self.bitmap = displayio.Bitmap(plot_width, plot_height,
+                                           self.num_colours)
             self.top_offset = 0
 
         self.palette = displayio.Palette(self.num_colours)
@@ -135,7 +140,7 @@ class ScreenPlotter:
                             self.bitmap[index, round(self.remap(self.old_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = 0
                     for subindex, point in enumerate(value):
                         # self.bitmap[index,round(((self.data_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = subindex + 1
-                        self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1                 
+                        self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1
             else:
                 try:
                     for subindex, point in enumerate(self.data_points[-1]):


### PR DESCRIPTION
The `plotters_combined` example dies with a `MemoryError` on a Feather nRF52840 Express with a PMS5003 attached to an Enviro+ FeatherWing. These changes address this.

- The ScreenPlotter now uses a fixed size circular buffer which is allocated once to reduce the amount of list operations - this should improve memory fragmentation which can be a serious problem on MicroPython/CircuitPython due to lack of compaction in GC. The value data no longer used (scrolled off screen) will still be GC'd. #19
- Pixel undraw code was broken for overlapping pixels, noticeable on some multi-line plots #22
- New arguments to constructor `width=None, height=None, extra_data=16, auto_show=True, auto_discard=True` #19 #23
  - width and height can now be specified or will default to screen values
  - `extra_data` is how many data_points are stored beyond those on the screen for efficient redrawing and allowing user program to jump scroll if desired.
  - `auto_show` allows the display.show to be disabled to allow a program more control and efficient use via `object.group`
  - `auto_discard` determines what happens if more data_points are added than `extra_data` without calling `draw()` - a `False` value will raise an exception.
- inhibits automatic screen refresh during bitmap update for minor efficiency improvements #23
- Clearing the bitmap now uses the more efficient `fill()` introduced in CircuitPython 5.3.0 #23
- New `plotter_test.py` to aid testing with visual verification and checking performance
 
Tested with `plotters_combined.py` and `plotter_test.py` on Feather nRF52840 Express with `6.0.0`. 
 - `plotters_combined` runs fine with PMS5003 in `passive` mode for at least 12.5hrs at `interval = 0.2` (code floors at 1s) based on testing. It starts around 53k free memory and stays constant at 30k once it starts scrolling.
 - `plotters_combined` runs fine with PMS5003 in `active` mode for at least 5hrs, rest is same as above.

No dependency on #21 but that could be reviewed at same time as this and applied beforehand.