### PR TITLE
Two new example programs to plot CO2 data from Sensirion SCD-30 using Adafruit libraries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/pimoroni/pms5003-circuitpython
 [submodule "submodules/circuitpython_adapter"]
 	path = submodules/circuitpython_adapter
-	url = https://github.com/pimoroni//circuitpython_adapter
+	url = https://github.com/pimoroni/circuitpython_adapter
 [submodule "submodules/physical_feather_pins"]
 	path = submodules/physical_feather_pins
 	url = https://github.com/pimoroni/physical_feather_pins

--- a/examples/plotter_scd30.py
+++ b/examples/plotter_scd30.py
@@ -1,0 +1,44 @@
+"""
+plotter_scd30.py
+
+Logs the level of carbon dioxide (CO2) in ppm over a 24hr period (by default).
+
+"""
+
+interval = 540 # full screen of reading spans 24hrs
+#interval = 1 # uncomment for 1 reading per second
+#interval = 60 # uncomment for 1 reading per minute
+#interval = 3600 # uncomment for 1 reading per hour
+
+import time
+
+import board
+import terminalio
+from adafruit_display_text import label
+from adafruit_scd30 import SCD30
+from pimoroni_envirowing.screen import plotter
+
+
+# colours for the plotter are defined as rgb values in hex, with 2 bytes for each colour
+red = 0xFF0000
+green = 0x00FF00
+blue = 0x0000FF
+
+# set up the sensor
+scd30 = SCD30(board.I2C())
+
+# Set up the plotter
+splotter = plotter.ScreenPlotter([green], max_value=3000, min_value=0, top_space=10)
+
+# add a colour coded text label for each reading
+splotter.group.append(label.Label(terminalio.FONT,
+                                  text="CO2: {:.0f} ppm",
+                                  color=green, x=0, y=5, max_glyphs=15))
+
+while True:
+    # take readings
+    co2ppm = scd30.CO2
+    splotter.update(co2ppm)
+    splotter.group[1].text = "CO2: {:.0f} ppm".format(co2ppm)
+
+    time.sleep(interval)

--- a/examples/plotter_scd30.py
+++ b/examples/plotter_scd30.py
@@ -27,6 +27,14 @@ blue = 0x0000FF
 # set up the sensor
 scd30 = SCD30(board.I2C())
 
+# The SCD-30 is more accurate if given local air pressure in mb (hPa)
+# which is available from the BME280 on the Enviro+ FeatherWing
+# The altitude in metres is a less accurate way of compensating for pressure
+# The altitude is remembered if the power is removed and is best set
+# only when needed to avoid wear on SCD-30 NVRAM
+#scd30.ambient_pressure = 1021
+#scd30.altitude = 123
+
 # Set up the plotter
 splotter = plotter.ScreenPlotter([green], max_value=3000, min_value=0, top_space=10)
 

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -109,6 +109,33 @@ def test_twolinesfewdraws(name, full_refresh=False):
             test_splotter.draw(full_refresh=full_refresh)
 
 
+def test_altandmiss(name, full_refresh=False):
+    """Draw three lines which alternate values to allow visual check on scrolling.
+       Also misses values on third line.
+    """
+    test_splotter = plotter.ScreenPlotter([red+green, green+blue, red+(blue>>1)],
+                                          top_space=10+10,
+                                          display=screen)
+
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text=name + (" CLS" if full_refresh else ""),
+                                           color=0xffffff, x=0, y=5))
+
+
+    for idx in range(180):
+        if idx >= 140:
+            time.sleep(0.25)
+
+        values = [40960 - idx % 2 * 2048,
+                  24576 + idx % 4 * 1024]
+        if idx % 4 >= 2:
+            values.append(32768)
+        test_splotter.update(*values,
+                             draw=not full_refresh)
+        if full_refresh:
+            test_splotter.draw(full_refresh=full_refresh)
+
+
 # full_refresh is currently (Dec-2020) very slow and very flickery unless
 # data update rate is very low
 screen_name = "Four lines, 3 ramping"
@@ -131,7 +158,6 @@ print(screen_name, "took",
       "seconds")
 time.sleep(15)
 
-
 screen_name = "Two lines, few draws"
 print(screen_name, "took",
       timeit(lambda: test_twolinesfewdraws(screen_name)),
@@ -139,5 +165,15 @@ print(screen_name, "took",
 time.sleep(10)
 print(screen_name, "took",
       timeit(lambda: test_twolinesfewdraws(screen_name, full_refresh=True)),
+      "seconds")
+time.sleep(15)
+
+screen_name = "Alternating, missing"
+print(screen_name, "took",
+      timeit(lambda: test_altandmiss(screen_name)),
+      "seconds")
+time.sleep(10)
+print(screen_name, "took",
+      timeit(lambda: test_altandmiss(screen_name, full_refresh=True)),
       "seconds")
 time.sleep(15)

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -1,0 +1,92 @@
+"""
+plotter_test.py
+
+This only tests some aspects of the plotter object.
+It does not display any data from the Enviro+ FeatherWing.
+"""
+
+
+import time
+import gc
+
+import pulseio
+import terminalio
+from adafruit_display_text import label
+
+import pimoroni_physical_feather_pins
+from pimoroni_envirowing import screen
+from pimoroni_envirowing.screen import plotter
+
+
+# Setup screen - this returns an ST7735R object
+screen = screen.Screen(backlight_control=False)
+
+# PWM for screen brightness
+backlight_pwm = pulseio.PWMOut(pimoroni_physical_feather_pins.pin21())
+backlight_pwm.duty_cycle = 65535  # full brightness
+
+red = 0xFF0000
+green = 0x00FF00
+blue = 0x0000FF
+
+
+def test_fourlines(name, full_refresh=False):
+    test_splotter = plotter.ScreenPlotter([red, green, blue, red+green+blue],
+                                          min_value=0, max_value=100, top_space=10+10,
+                                          display=screen)
+
+    # add a colour coded text label for each reading
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text="A: {:.0f}",
+                                           color=red, x=0, y=5, max_glyphs=15))
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text="B: {:.0f}",
+                                           color=green, x=50, y=5, max_glyphs=15))
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text="C: {:.0f}",
+                                           color=blue, x=110, y=5, max_glyphs=15))
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text=name + (" CLS" if full_refresh else ""),
+                                           color=0xffffff, x=0, y=5))
+
+    for idx in range(200):
+        time.sleep(0.050)
+        test_splotter.update((idx * 2 + 50) % 121,
+                             (idx * 2 + 20) % 101,
+                             idx * 4 % 101,
+                             50,
+                             draw=not full_refresh)
+        if full_refresh:
+            test_splotter.draw(full_refresh)
+
+
+def test_threeflatlines(name, full_refresh=False):
+    test_splotter = plotter.ScreenPlotter([red, green, blue],
+                                          min_value=0, max_value=100, top_space=10,
+                                          display=screen)
+
+    test_splotter.group.append(label.Label(terminalio.FONT,
+                                           text=name + (" CLS" if full_refresh else ""),
+                                           color=0xffffff, x=0, y=5))
+
+    for _ in range(200):
+        time.sleep(0.050)
+        test_splotter.update(0,
+                             50,
+                             100,
+                             draw=not full_refresh)
+
+        if full_refresh:
+            test_splotter.draw(full_refresh)
+
+
+# full_refresh is currently (Dec-2020) very slow and very flickery unless
+# data update rate is very low
+test_fourlines("Four lines, 3 ramping")
+time.sleep(10)
+test_fourlines("Four lines, 3 ramping", full_refresh=True)
+time.sleep(15)
+test_threeflatlines("Three flat lines")
+time.sleep(10)
+test_threeflatlines("Three flat lines", full_refresh=True)
+time.sleep(15)

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -102,13 +102,17 @@ def test_twolinesfewdraws(name, full_refresh=False):
                                            color=0xffffff, x=0, y=5))
     screen.show(test_splotter.group)
 
-    for idx in range(200):
+    for idx in range(200 + 32):
         time.sleep(0.050)
         test_splotter.update((idx * 50 + 20) % 1001,
                              (idx * 2 + 300) % 1001,
                              draw=False)
-        if idx % 4 == 0:
+        # draw every 4 columns for first 200 columns but skip after that to
+        # test going beyond internal circular buffer size
+        if idx % 4 == 0 and idx < 200:
             test_splotter.draw(full_refresh=full_refresh)
+
+    test_splotter.draw(full_refresh=full_refresh)
 
 
 def test_altandmiss(name, full_refresh=False):

--- a/examples/plotter_test.py
+++ b/examples/plotter_test.py
@@ -41,7 +41,7 @@ def timeit(func):
 def test_fourlines(name, full_refresh=False):
     test_splotter = plotter.ScreenPlotter([red, green, blue, red+green+blue],
                                           min_value=0, max_value=100, top_space=10+10,
-                                          display=screen)
+                                          display=screen, auto_show=False)
 
     # add a colour coded text label for each reading
     test_splotter.group.append(label.Label(terminalio.FONT,
@@ -56,6 +56,7 @@ def test_fourlines(name, full_refresh=False):
     test_splotter.group.append(label.Label(terminalio.FONT,
                                            text=name + (" CLS" if full_refresh else ""),
                                            color=0xffffff, x=0, y=5))
+    screen.show(test_splotter.group)
 
     for idx in range(200):
         time.sleep(0.050)
@@ -94,11 +95,12 @@ def test_twolinesfewdraws(name, full_refresh=False):
     """
     test_splotter = plotter.ScreenPlotter([red+green, green+blue],
                                           min_value=0, max_value=1000, top_space=10+10,
-                                          display=screen)
+                                          display=screen, auto_show=False)
 
     test_splotter.group.append(label.Label(terminalio.FONT,
                                            text=name + (" CLS" if full_refresh else ""),
                                            color=0xffffff, x=0, y=5))
+    screen.show(test_splotter.group)
 
     for idx in range(200):
         time.sleep(0.050)
@@ -115,12 +117,12 @@ def test_altandmiss(name, full_refresh=False):
     """
     test_splotter = plotter.ScreenPlotter([red+green, green+blue, red+(blue>>1)],
                                           top_space=10+10,
-                                          display=screen)
+                                          display=screen, auto_show=False)
 
     test_splotter.group.append(label.Label(terminalio.FONT,
                                            text=name + (" CLS" if full_refresh else ""),
                                            color=0xffffff, x=0, y=5))
-
+    screen.show(test_splotter.group)
 
     for idx in range(180):
         if idx >= 140:

--- a/examples/plotters_combined.py
+++ b/examples/plotters_combined.py
@@ -174,7 +174,7 @@ while True:
         # if proximity confidence above threshold, change page
         if prox > prox_threshold:
             current_page = next(page)
-            available_pages[current_page].draw(full_refresh=True)
+            available_pages[current_page].draw(full_refresh=True, show=True)
         else:
             # change screen brightness according to the amount of light detected
             pwm.duty_cycle = int(min(lightandsound_splotter.remap(lux, 0, 400, 0, (2**16 - 1)), (2**16 - 1)))

--- a/examples/plotters_combined_with_scd30.py
+++ b/examples/plotters_combined_with_scd30.py
@@ -65,7 +65,9 @@ except Exception as e:
 
 # set up the scd30
 try:
-    scd30 = SCD30(i2c)
+    pressure = bme280.pressure
+    last_pressure = round(pressure)
+    scd30 = SCD30(i2c, ambient_pressure=last_pressure)
     is_scd30 = True
 except (NameError, ValueError, OSError) as ex:
     print(ex)
@@ -298,6 +300,9 @@ while True:
 
             if is_scd30:
                 # take readings
+                if last_pressure != round(pressure):
+                    last_pressure = round(pressure)
+                    scd30.ambient_pressure = last_pressure
                 co2ppm = scd30.CO2
                 scd30_splotter.update(co2ppm,
                                       draw=False)

--- a/examples/plotters_combined_with_scd30.py
+++ b/examples/plotters_combined_with_scd30.py
@@ -67,7 +67,7 @@ except Exception as e:
 try:
     scd30 = SCD30(i2c)
     is_scd30 = True
-except (ValueError, OSError) as ex:
+except (NameError, ValueError, OSError) as ex:
     print(ex)
     print("You probably don't have an scd30 connected, continuing without CO2 logging")
     is_scd30 = False

--- a/examples/plotters_combined_with_scd30.py
+++ b/examples/plotters_combined_with_scd30.py
@@ -203,7 +203,7 @@ while True:
         # if proximity confidence above threshold, change page
         if prox > prox_threshold:
             current_page = next(page)
-            available_pages[current_page].draw(full_refresh=True)
+            available_pages[current_page].draw(full_refresh=True, show=True)
         else:
             # change screen brightness according to the amount of light detected
             pwm.duty_cycle = int(min(lightandsound_splotter.remap(lux, 0, 400, 0, (2**16 - 1)), (2**16 - 1)))

--- a/examples/plotters_combined_with_scd30.py
+++ b/examples/plotters_combined_with_scd30.py
@@ -1,0 +1,323 @@
+"""
+plotters_combined_with_scd30.py
+
+Combines all the plotters into one program, recording values over a 24hr period (by default).
+Allows you to switch page by waving your hand over the screen.
+Plotting PMS5003 and SCD30 is likely to use more memory than is available on Feather M4 (192kB) -
+Feather nRF52840 Express (256kB) works well.
+"""
+interval = 540 # full screen of reading spans 24hrs
+#interval = 1 # uncomment for 1 reading per second
+#interval = 60 # uncomment for 1 reading per minute
+#interval = 3600 # uncomment for 1 reading per hour
+
+# the higher the threshold value the less sensitive, we've found this to be a good default through testing
+mic_threshold = 3100
+
+# the threshold for the proximity detection, the higher the less sensitive
+prox_threshold = 100
+
+# Setup
+import time
+import math
+import gc
+
+import adafruit_bme280
+import analogio
+import board
+import busio
+import displayio
+import pulseio
+import terminalio
+from adafruit_display_text import label
+
+import pimoroni_physical_feather_pins
+from pimoroni_circuitpython_adapter import not_SMBus
+from pimoroni_envirowing import gas, screen
+from pimoroni_envirowing.screen import plotter
+from pimoroni_ltr559 import LTR559
+from pimoroni_pms5003 import PMS5003
+
+# optional Adafruit library for SCD30
+try:
+    from adafruit_scd30 import SCD30
+except ImportError:
+    pass
+
+#print("(", gc.mem_free(), ")")
+
+# set up the connection with the bme280
+i2c = busio.I2C(board.SCL, board.SDA)
+bme280 = adafruit_bme280.Adafruit_BME280_I2C(i2c, address=0x76)
+
+# average global sea level pressure, for more accurate readings change this to your local sea level pressure (measured in hPa)
+bme280.sea_level_pressure = 1013.25
+
+# set up the pms5003
+pms5003 = PMS5003()
+try:
+    pms5003.read()
+    is_pms5003 = True
+except Exception as e:
+    print(e)
+    print("You probably don't have a pms5003 connected, continuing without particulate logging")
+    is_pms5003 = False
+
+# set up the scd30
+try:
+    scd30 = SCD30(i2c)
+    is_scd30 = True
+except (ValueError, OSError) as ex:
+    print(ex)
+    print("You probably don't have an scd30 connected, continuing without CO2 logging")
+    is_scd30 = False
+
+# set up connection with the ltr559
+i2c_dev = not_SMBus(I2C=i2c)
+ltr559 = LTR559(i2c_dev=i2c_dev)
+
+# setup screen
+screen = screen.Screen(backlight_control=False)
+
+# define our pwm pin (for changing the screen brightness)
+pwm = pulseio.PWMOut(pimoroni_physical_feather_pins.pin21())
+
+# start the screen at 50% brightness
+pwm.duty_cycle = 2**15
+
+# set up mic input
+mic = analogio.AnalogIn(pimoroni_physical_feather_pins.pin8())
+
+# colours for the plotter are defined as rgb values in hex, with 2 bytes for each colour
+red = 0xFF0000
+green = 0x00FF00
+blue = 0x0000FF
+
+# Setup bme280 screen plotter
+# the max value is set to 70 as it is the screen height in pixels after the labels (top_space) (this is just to make a calculation later on easier)
+bme280_splotter = plotter.ScreenPlotter([red, green, blue, red+green+blue], max_value=70, min_value=0, top_space=10, display=screen)
+
+# add a colour coded text label for each reading
+bme280_splotter.group.append(label.Label(terminalio.FONT, text="{:0.1f} C".format(bme280.temperature), color=red, x=0, y=5, max_glyphs=15))
+bme280_splotter.group.append(label.Label(terminalio.FONT, text="{:0.1f} hPa".format(bme280.pressure), color=green, x=50, y=5, max_glyphs=15))
+bme280_splotter.group.append(label.Label(terminalio.FONT, text="{:0.1f} %".format(bme280.humidity), color=blue, x=120, y=5, max_glyphs=15))
+#bme280_splotter.group.append(label.Label(terminalio.FONT, text="{:0.2f} m".format(bme280.altitude), color=red+green+blue, x=40, y=20, max_glyphs=15)) # uncomment for altitude estimation
+
+# if the pms5003 is connected
+if is_pms5003:
+    # Set up the pms5003 screen plotter
+    # the max value is set to 1000 as a nice number to work with
+    pms5003_splotter = plotter.ScreenPlotter([green, blue, red+blue+green], max_value=1000, min_value=0, top_space=10, display=screen)
+
+    # add a colour coded text label for each reading
+    pms5003_splotter.group.append(label.Label(terminalio.FONT, text="PM2.5: {:d}", color=green, x=0, y=5, max_glyphs=15))
+    pms5003_splotter.group.append(label.Label(terminalio.FONT, text="PM10: {:d}", color=blue, x=80, y=5, max_glyphs=15))
+    #pms5003_splotter.group.append(label.Label(terminalio.FONT, text="PM1.0: {:d}", color=red, x=0, y=20, max_glyphs=15)) # uncomment to enable PM1.0 measuring
+
+    # red line for the WHO guideline (https://en.wikipedia.org/wiki/Air_quality_guideline)
+    # made in a new bitmap so it doesn't get overwritten
+    pms5003_splotter.redline_bm = displayio.Bitmap(160, 1, 1)
+    pms5003_splotter.redline_pl = displayio.Palette(1)
+    pms5003_splotter.redline_pl[0] = red
+    pms5003_splotter.redline_tg = displayio.TileGrid(pms5003_splotter.redline_bm, pixel_shader=pms5003_splotter.redline_pl, x=0, y=44)
+    pms5003_splotter.group.append(pms5003_splotter.redline_tg)
+
+# if an scd30 is connected
+if is_scd30:
+    # Set up the scd30 screen plotter
+    scd30_splotter = plotter.ScreenPlotter([green], max_value=3000, min_value=0, top_space=10, display=screen)
+
+    # add a colour coded text label for each reading
+    scd30_splotter.group.append(label.Label(terminalio.FONT, text="CO2: {:.0f} ppm", color=green, x=0, y=5, max_glyphs=15))
+
+# Set up the gas screen plotter
+# the max value is set to 3.3 as its the max voltage the feather can read
+gas_splotter = plotter.ScreenPlotter([red, green, blue], max_value=3.3, min_value=0.5, top_space=10, display=screen)
+
+# add a colour coded text label for each reading
+gas_splotter.group.append(label.Label(terminalio.FONT, text="OX: {:.0f}", color=red, x=0, y=5, max_glyphs=15))
+gas_splotter.group.append(label.Label(terminalio.FONT, text="RED: {:.0f}", color=green, x=50, y=5, max_glyphs=15))
+gas_splotter.group.append(label.Label(terminalio.FONT, text="NH3: {:.0f}", color=blue, x=110, y=5, max_glyphs=15))
+
+# from https://stackoverflow.com/a/49955617
+def human_format(num, round_to=0):
+    magnitude = 0
+    while abs(num) >= 1000:
+        magnitude += 1
+        num = round(num / 1000.0, round_to)
+    return '{:.{}f}{}'.format(round(num, round_to), round_to, ['', 'K', 'M', 'G', 'T', 'P'][magnitude])
+
+# set up the light&sound plotter
+lightandsound_splotter = plotter.ScreenPlotter([green, blue], display=screen, max_value=1, top_space=10)
+
+# add a colour coded text label for each reading
+lightandsound_splotter.group.append(label.Label(terminalio.FONT, text="Sound", color=green, x=0, y=5, max_glyphs=15))
+lightandsound_splotter.group.append(label.Label(terminalio.FONT, text="Light", color=blue, x=80, y=5, max_glyphs=15))
+
+# record the time that the sampling starts
+last_reading = time.monotonic()
+last_sec = time.monotonic()
+
+# initialise counters at 0
+reading = 0
+readings = 0
+
+# init the available pages
+available_pages = {
+    1: bme280_splotter,
+    2: gas_splotter,
+    3: lightandsound_splotter
+}
+
+# if pms5003 detected, add to available pages
+if is_pms5003:
+    available_pages.update({0:pms5003_splotter})
+
+# if scd30 detected, add to available pages
+if is_scd30:
+    available_pages.update({4:scd30_splotter})
+
+current_page = 3
+
+# create a generator that will give the next page index, looping back to 0 once it reaches the end
+def page_turner(available_pages):
+    while True:
+        for i in sorted(available_pages.keys()):
+            yield i
+
+# init the generator
+page = page_turner(available_pages)
+
+#print("(", gc.mem_free(), ")")
+
+while True:
+    # if 1 second has passed
+    if last_sec + 1 < time.monotonic():
+
+        # take the light reading
+        lux = ltr559.get_lux()
+
+        # take a proximity reading
+        prox = ltr559.get_proximity()
+
+        # if proximity confidence above threshold, change page
+        if prox > prox_threshold:
+            current_page = next(page)
+            available_pages[current_page].draw(full_refresh=True)
+        else:
+            # change screen brightness according to the amount of light detected
+            pwm.duty_cycle = int(min(lightandsound_splotter.remap(lux, 0, 400, 0, (2**16 - 1)), (2**16 - 1)))
+
+        # if interval time has passed since last reading
+        if last_reading + interval < time.monotonic():
+
+            # take readings
+            temperature = bme280.temperature
+            pressure = bme280.pressure
+            humidity = bme280.humidity
+            #altitude = bme280.altitude # uncomment for altitude estimation
+
+            # update the line graph
+            bme280_splotter.update(
+                # scale to 70 as that's the number of pixels height available
+                bme280_splotter.remap(temperature, 0, 50, 0, 70),
+                bme280_splotter.remap(pressure, 975, 1025, 0, 70),
+                bme280_splotter.remap(humidity, 0, 100, 0, 70),
+                #bme280_splotter.remap(altitude, 0, 1000, 0, 70), # uncomment for altitude estimation
+                draw=False
+            )
+
+            # update the labels
+            bme280_splotter.group[1].text = "{:0.1f} C".format(temperature)
+            bme280_splotter.group[2].text = "{:0.1f} hPa".format(pressure)
+            bme280_splotter.group[3].text = "{:0.1f} %".format(humidity)
+            #bme280_splotter.group[4].text = "{:0.2f} m".format(altitude) # uncomment for altitude estimation
+
+            gc.collect()
+
+            # take readings
+            gas_reading = gas.read_all()
+
+            # update the line graph
+            # the value plotted on the graph is the voltage drop over each sensor, not the resistance, as it graphs nicer
+            gas_splotter.update(
+                gas_reading._OX.value * (gas_reading._OX.reference_voltage/65535),
+                gas_reading._RED.value * (gas_reading._RED.reference_voltage/65535),
+                gas_reading._NH3.value * (gas_reading._NH3.reference_voltage/65535),
+                draw=False
+            )
+
+            # update the labels
+            gas_splotter.group[1].text = "OX:{}".format(human_format(gas_reading.oxidising))
+            gas_splotter.group[2].text = "RED:{}".format(human_format(gas_reading.reducing))
+            gas_splotter.group[3].text = "NH3:{}".format(human_format(gas_reading.nh3))
+
+            gc.collect()
+
+            # get the sound readings (number of samples over the threshold / total number of samples taken) and apply a logarithm function to them to represent human hearing
+            sound_level = math.log((reading/readings) + 1, 2)
+            # weight the result using a -2x^3 + 3x^2 curve to emphasise changes around the midpoint (0.5)
+            sound_level = (-2* sound_level**3 + 3* sound_level**2)
+            # then weight the result using a x^3 - 3x^2 + 3x curve to make the results fill the graph and not sit at the bottom
+            sound_level = (sound_level**3 - 3*sound_level**2 + 3*sound_level)
+
+            # update the line graph
+            lightandsound_splotter.update(
+                sound_level,
+                lightandsound_splotter.remap(lux, 0, 1000, 0, 1),
+                draw=False
+            )
+
+            # update the labels
+            lightandsound_splotter.group[1].text = "Sound: {:1.2f}".format(sound_level)
+            lightandsound_splotter.group[2].text = "Light: {:.0f}".format(lux)
+
+            gc.collect()
+
+            if is_pms5003:
+                # take readings
+                pms_reading = pms5003.read()
+                pm2 = pms_reading.data[1]
+                pm10 = pms_reading.data[2]
+                #pm1 = pms_reading.data[0] # uncomment to enable PM1.0 measuring
+
+                # update the line graph
+                pms5003_splotter.update(
+                    pms5003_splotter.remap(pm2, 0, 50, 0, 1000),
+                    pms5003_splotter.remap(pm10, 0, 100, 0, 1000),
+                    #pms5003_splotter.remap(pm1, 0, 100, 0, 1000), # uncomment to enable PM1.0 measuring
+                    draw=False
+                )
+
+                # update the labels
+                pms5003_splotter.group[1].text = "PM2.5: {:d}".format(pm2)
+                pms5003_splotter.group[2].text = "PM10: {:d}".format(pm10)
+                #pms5003_splotter.group[3].text = "PM1.0: {:d}".format(pm1) # uncomment to enable PM1.0 measuring
+
+                gc.collect()
+
+            if is_scd30:
+                # take readings
+                co2ppm = scd30.CO2
+                scd30_splotter.update(co2ppm,
+                                      draw=False)
+                scd30_splotter.group[1].text = "CO2: {:.0f} ppm".format(co2ppm)
+
+            available_pages[current_page].draw()
+
+            # reset the sound readings counters
+            reading = 0
+            readings = 0
+            # record the time that this reading was taken
+            last_reading = time.monotonic()
+
+            #print("(", gc.mem_free(), ")")
+
+        # update the last_sec time
+        last_sec = time.monotonic()
+
+    # take a sample of the current mic voltage
+    sample = abs(mic.value - 32768)
+    readings += 1
+    if sample > mic_threshold:
+        reading += 1

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -1,7 +1,7 @@
 class ScreenPlotter:
     def __init__(self, colours, bg_colour=None, max_value=None, min_value=None,
                  display=None, top_space=None, width=None, height=None,
-                 extra_data=16):
+                 extra_data=16, auto_show=True):
         """__init__
 
         :param list colours: a list of colours to use for data lines
@@ -21,6 +21,8 @@ class ScreenPlotter:
         :param int height: the height in pixels of the plot (uses display width if not supplied)
 
         :param int extra_data: the number of updates that can be applied before a draw (16 if not supplied)
+
+        :param bool auto_show: invoke show on the displayio object here and per execution of draw() (default True)
         """
         import displayio
 
@@ -55,12 +57,12 @@ class ScreenPlotter:
             self.palette[i + 1] = j
 
         self.tile_grid = displayio.TileGrid(self.bitmap, pixel_shader=self.palette, y=self.top_offset)
-
         self.group = displayio.Group(max_size=12)
-
         self.group.append(self.tile_grid)
 
-        self.display.show(self.group)
+        self.auto_show = auto_show
+        if self.auto_show:
+            self.display.show(self.group)
 
         if max_value:
             self.max_value = max_value
@@ -113,11 +115,13 @@ class ScreenPlotter:
         if draw:
             self.draw()
 
-    def draw(self, full_refresh=False):
+    def draw(self, full_refresh=False, show=False):
         """draw
 
         :param bool full_refresh: select clear bitmap algorithm when scrolling,
                                   default is to undraw individual prevously drawn pixels
+
+        :param bool show: force show on the displayio object (default False)
         """
         new_points = (self.data_tail - self.display_tail if self.data_tail >= self.display_tail
                       else self.data_len - self.display_tail + self.data_tail)
@@ -170,3 +174,7 @@ class ScreenPlotter:
 
         if restore_auto_refresh:
             self.display.auto_refresh = True
+
+        # Slightly inefficient and generally unnecessary to show() per draw
+        if show or self.auto_show:
+            self.display.show(self.group)

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -110,6 +110,11 @@ class ScreenPlotter:
             self.draw()
 
     def draw(self, full_refresh=False):
+        restore_auto_refresh = False
+        if self.display.auto_refresh:
+            self.display.auto_refresh = False
+            restore_auto_refresh = True
+
         if not full_refresh:
             if len(self.data_points) > self.bitmap.width:
                 difflen = len(self.data_points) - self.bitmap.width
@@ -152,4 +157,6 @@ class ScreenPlotter:
                         self.bitmap[index, round(self.remap(point, self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1
             except IndexError:
                 print("You shouldn't call draw() without calling update() first")
-        self.display.show(self.group)
+
+        if restore_auto_refresh:
+            self.display.auto_refresh = True

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -134,7 +134,7 @@ class ScreenPlotter:
         """
         new_points = (self.data_tail - self.display_tail if self.data_tail >= self.display_tail
                       else self.data_len - self.display_tail + self.data_tail)
-        if new_points == 0:
+        if new_points == 0 and not full_refresh and not show:
             return
 
         restore_auto_refresh = False

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -144,9 +144,7 @@ class ScreenPlotter:
                     self.data_points = self.data_points[difflen:]
 
                 # clear bitmap
-                for x in range(self.bitmap.width):
-                    for y in range(self.bitmap.height):
-                        self.bitmap[x, y] = 0
+                self.bitmap.fill(0)
 
                 for index, value in enumerate(self.data_points):
                     for subindex, point in enumerate(value):

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -31,7 +31,6 @@ class ScreenPlotter:
         else:
             self.display = display
 
-        self.num_lines = len(colours)
         self.num_colours = len(colours) + 1
 
         plot_width = display.width if width is None else width
@@ -99,8 +98,8 @@ class ScreenPlotter:
         if self.data_tail == (self.data_head - 1) % self.data_len:
             raise OverflowError("data_points full")
 
-        if len(values) != self.num_lines:
-            raise Exception("The list of values should match the number of colours")
+        if len(values) > self.num_colours - 1:
+            raise OverflowError("The list of values shouldn't have more entries than the list of colours")
 
         for i, j in enumerate(values):
             if j > self.max_value:
@@ -139,10 +138,10 @@ class ScreenPlotter:
                 for index, dpnew_index in zip(range(self.bitmap.width),
                                               range(self.data_tail - self.bitmap.width, self.data_tail)):
                     # undraw old pixels if they were in a different position
-                    for subindex, new_value in enumerate(self.data_points[dpnew_index]):
-                        old_values = self.data_points[self.display_tail - self.displayed_points + index] if index < self.displayed_points else None
-                        if old_values is not None and old_values[subindex] != new_value:
-                            self.bitmap[index, round(self.remap(old_values[subindex], self.min_value, self.max_value, heightm1, 0))] = 0
+                    old_values = self.data_points[self.display_tail - self.displayed_points + index] if index < self.displayed_points else []
+                    for old_value in old_values:
+                        self.bitmap[index, round(self.remap(old_value, self.min_value, self.max_value, heightm1, 0))] = 0
+
                     # draw new pixels - this must be performed unconditionally
                     # to cater for overlapping lines
                     for subindex, new_value in enumerate(self.data_points[dpnew_index]):

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -133,8 +133,9 @@ class ScreenPlotter:
                         if point != 0:
                             # self.bitmap[index,round(((old_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = 0
                             self.bitmap[index, round(self.remap(self.old_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = 0
-                            # self.bitmap[index,round(((self.data_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = subindex + 1
-                            self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1
+                    for subindex, point in enumerate(value):
+                        # self.bitmap[index,round(((self.data_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = subindex + 1
+                        self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1                 
             else:
                 try:
                     for subindex, point in enumerate(self.data_points[-1]):

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -37,8 +37,8 @@ class ScreenPlotter:
 
         self.num_colours = len(colours) + 1
 
-        plot_width = display.width if width is None else width
-        plot_height = display.height if height is None else height
+        plot_width = self.display.width if width is None else width
+        plot_height = self.display.height if height is None else height
         if top_space:
             self.bitmap = displayio.Bitmap(plot_width, plot_height - top_space,
                                            self.num_colours)

--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -1,5 +1,6 @@
 class ScreenPlotter:
-    def __init__(self, colours, bg_colour=None, max_value=None, min_value=None, display=None, top_space=None):
+    def __init__(self, colours, bg_colour=None, max_value=None, min_value=None,
+                 display=None, top_space=None, width=None, height=None):
         """__init__
 
         :param list colours: a list of colours to use for data lines
@@ -25,11 +26,15 @@ class ScreenPlotter:
 
         self.num_colours = len(colours) + 1
 
+        plot_width = display.width if width is None else width
+        plot_height = display.height if height is None else height
         if top_space:
-            self.bitmap = displayio.Bitmap(160, 80 - top_space, self.num_colours)
+            self.bitmap = displayio.Bitmap(plot_width, plot_height - top_space,
+                                           self.num_colours)
             self.top_offset = top_space
         else:
-            self.bitmap = displayio.Bitmap(160, 80, self.num_colours)
+            self.bitmap = displayio.Bitmap(plot_width, plot_height,
+                                           self.num_colours)
             self.top_offset = 0
 
         self.palette = displayio.Palette(self.num_colours)
@@ -135,7 +140,7 @@ class ScreenPlotter:
                             self.bitmap[index, round(self.remap(self.old_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = 0
                     for subindex, point in enumerate(value):
                         # self.bitmap[index,round(((self.data_points[index][subindex] - self.min_value) / self.value_range) * -(self.bitmap.height -1) + (self.bitmap.height -1))] = subindex + 1
-                        self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1                 
+                        self.bitmap[index, round(self.remap(self.data_points[index][subindex], self.min_value, self.max_value, self.bitmap.height - 1, 0))] = subindex + 1
             else:
                 try:
                     for subindex, point in enumerate(self.data_points[-1]):


### PR DESCRIPTION
Two new programs for #25 to plot CO2 from (Adafruit) Sensirion SCD-30 using https://github.com/adafruit/Adafruit_CircuitPython_SCD30 library.

 - `examples/plotter_scd30.py` - plot up to 3000ppm. 1b95f08f60282727a4482948d7bbb395cbe6ada2 064cb2564ef402e1ec738afb02020a33725feba3
 - `examples/plotters_combined_with_scd30.py` - fourth optional plot page based on the `adafruit_scd30` library being present and the `SCD30` object initialises ok, i.e. device is plugged in and responding over i2c. This version also passes the pressure to the SCD-30. 5af87611c242bd68ea7396c502ff84257e08e719 8e5377a40c825a8359e67b8765b55605f53d455b

The combined one is a new file rather put all the functionality into `plotters_combined.py` as that's getting a little large in memory usage terms and SCD-30 users are probably in the minority.

Tested on a Feather nRF52840 Express running 6.2.0 and brand new Enviro+ FeatherWing: [Plotting Carbon Dioxide concentration with Enviro+ FeatherWing and Sensirion SCD-30 NDIR Sensor](https://www.youtube.com/watch?v=Szn-ZCr0kYg) (YouTube).

https://github.com/pimoroni/EnviroPlus-FeatherWing/pull/26/commits/288953d6001538370d0e829b3f4828a81c74e31c is same type of bugfix as https://github.com/pimoroni/EnviroPlus-FeatherWing/pull/24/commits/0c2cf96455fc9a396bd7e444d476503bfd2230c6