### PR TITLE
Remove the deprecated max_size argument in a Group() call.

### DIFF
--- a/library/pimoroni_envirowing/screen/plotter.py
+++ b/library/pimoroni_envirowing/screen/plotter.py
@@ -44,7 +44,7 @@ class ScreenPlotter:
 
         self.tile_grid = displayio.TileGrid(self.bitmap, pixel_shader=self.palette, y=self.top_offset)
 
-        self.group = displayio.Group(max_size=12)
+        self.group = displayio.Group()
 
         self.group.append(self.tile_grid)
 


### PR DESCRIPTION
The presence of this argument causes modern version of the displayio library to log a warning.